### PR TITLE
Fix crash when upstream proxy is not used

### DIFF
--- a/tasks/shared/proxy.js
+++ b/tasks/shared/proxy.js
@@ -20,6 +20,8 @@ module.exports = function (grunt) {
         protocol = url.parse(proxyURL).protocol === 'https:' ? 'https' : 'http';
         protocolImpl = require(protocol);
         protocol += ':';
+    } else {
+        protocolImpl = require('http');
     }
 
     var appserverUrl;


### PR DESCRIPTION
The upstream proxy feature made the HTTP library variable depending on whether the upstream proxy uses HTTP or HTTPS. It was even set correctly when an upstream proxy was used. But the old (and still predominant) use case of no upstream proxy was forgotten, and trying to use the HTTP library crashed immediately when a non-HTTPS request was proxied.